### PR TITLE
Fix padding in CNN_Text_Classification.ipynb

### DIFF
--- a/CNN_Text_Classification.ipynb
+++ b/CNN_Text_Classification.ipynb
@@ -791,7 +791,7 @@
     "        \n",
     "        # 2. convolutional layers\n",
     "        self.convs_1d = nn.ModuleList([\n",
-    "            nn.Conv2d(1, num_filters, (k, embedding_dim), padding=k-2) \n",
+    "            nn.Conv2d(1, num_filters, (k, embedding_dim), padding=(k-2, 0)) \n",
     "            for k in kernel_sizes])\n",
     "        \n",
     "        # 3. final, fully-connected layer for classification\n",


### PR DESCRIPTION
We shouldn't add padding in the width dimension so we don't do extra convolution operations which will results in a bad tensor size. 

Fix #2 